### PR TITLE
Generate a new ad session upon content update.

### DIFF
--- a/src/videojs.pulse.js
+++ b/src/videojs.pulse.js
@@ -35,6 +35,7 @@
             var playlistCurrentItem = 0;
             var pauseAdTimeout = null;
             var isFree = false;
+            var contentUpdated = false;
 
             if(!OO || !OO.Pulse) {
                 throw new Error('The Pulse SDK is not included in the page. Be sure to load it before the Pulse plugin for videojs.');
@@ -140,6 +141,10 @@
                     //The video was changed, we need to stop the previous session
                     resetPlugin();
                     playlistCurrentItem = player.playlist.currentItem();
+                    createSession();
+                }else if (contentUpdated){
+                    contentUpdated = false;
+                    resetPlugin();
                     createSession();
                 }
             };
@@ -450,6 +455,11 @@
 
             }
 
+            function contentupdate() {
+                contentUpdated = true;
+                createSession();
+            }
+
             //Time update callback for videojs
             function timeUpdate(){
                 if(sessionIsValid()) {
@@ -485,6 +495,7 @@
             //Register the relevant event listeners
             function registerPlayerEventListeners(){
                 player.on('readyforpreroll',readyForPreroll);
+                player.on('contentupdate',contentupdate);
                 player.on('timeupdate', timeUpdate);
                 player.on('contentended', contentEnded);
                 player.on('playing', contentPlayback);
@@ -497,6 +508,7 @@
 
             function unregisterPlayerEventListeners(){
                 player.off('readyforpreroll', readyForPreroll);
+                player.off('contentupdate',contentupdate);
                 player.off('timeupdate', timeUpdate);
                 player.off('contentended', contentEnded);
                 player.off('contentplayback', contentPlayback);


### PR DESCRIPTION
Ooyala videojs plugin now supports two ways of creating a new session:
-When the plugin is instantiated and no ad session is present yet.
-After the video video content is changed through the playlist module.

For cases where a session has been already initiated and the content has changed, there's no way for the plugin to know that it has to initiate a new session, therefore, we are adding a listener for the "contentupdate" event from contrib-ads (https://github.com/videojs/videojs-contrib-ads#developing-an-integration) in order to initiate a new session right after the content has changed through the player.src() method for instance.

As mentioned in contrib-ads readme file, "contentupdate" won't be triggered while the integration is playing an ad, therefore, whoever changes the source needs to be careful of not doing it while an ad is being played, otherwise the "contentupdate" event won't be triggered and the session won't be created.